### PR TITLE
resource permission source + resource permission provider

### DIFF
--- a/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
+++ b/fiat-core/src/main/java/com/netflix/spinnaker/fiat/model/resources/Permissions.java
@@ -27,8 +27,8 @@ import lombok.val;
 
 /**
  * Representation of authorization configuration for a resource. This object is immutable, which
- * makes it challenging when working with Jackson's {{ObjectMapper}} and Spring's
- * {{\@ConfigurationProperties}}. The {@link Builder} is a helper class for the latter use case.
+ * makes it challenging when working with Jackson's {@code ObjectMapper} and Spring's
+ * {@code @ConfigurationProperties}. The {@link Builder} is a helper class for the latter use case.
  */
 @ToString
 @EqualsAndHashCode
@@ -90,7 +90,7 @@ public class Permissions {
   }
 
   public List<String> get(Authorization a) {
-    return permissions.get(a);
+    return permissions.getOrDefault(a, Collections.emptyList());
   }
 
   /**

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AccessControlledResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AccessControlledResourcePermissionSource.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+import java.util.Optional;
+
+public final class AccessControlledResourcePermissionSource<T extends Resource.AccessControlled>
+    implements ResourcePermissionSource<T> {
+
+  @Override
+  public Permissions getPermissions(T resource) {
+    return Optional.ofNullable(resource.getPermissions())
+        .filter(Permissions::isRestricted)
+        .orElse(Permissions.EMPTY);
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/AggregatingResourcePermissionProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+import java.util.List;
+
+/**
+ * AggregatingResourcePermissionProvider additively combines permissions from all
+ * ResourcePermissionSources to build a resulting Permission object.
+ *
+ * @param <T> the type of Resource for this AggregatingResourcePermissionProvider
+ */
+public class AggregatingResourcePermissionProvider<T extends Resource>
+    implements ResourcePermissionProvider<T> {
+
+  private final List<ResourcePermissionSource<T>> resourcePermissionSources;
+
+  public AggregatingResourcePermissionProvider(
+      List<ResourcePermissionSource<T>> resourcePermissionSources) {
+    this.resourcePermissionSources = resourcePermissionSources;
+  }
+
+  @Override
+  public Permissions getPermissions(T resource) {
+    Permissions.Builder builder = new Permissions.Builder();
+    for (ResourcePermissionSource<T> source : resourcePermissionSources) {
+      Permissions permissions = source.getPermissions(resource);
+      if (permissions.isRestricted()) {
+        for (Authorization auth : Authorization.values()) {
+          List<String> roles = permissions.get(auth);
+          if (roles != null && !roles.isEmpty()) {
+            builder.add(auth, roles);
+          }
+        }
+      }
+    }
+
+    Permissions aggregate = builder.build();
+    if (aggregate.isEmpty()) {
+      return Permissions.EMPTY;
+    }
+
+    return aggregate;
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/BaseResourceProvider.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
-public abstract class BaseProvider<R extends Resource> implements ResourceProvider<R> {
+public abstract class BaseResourceProvider<R extends Resource> implements ResourceProvider<R> {
 
   private static final Integer CACHE_KEY = 0;
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultApplicationResourceProvider.java
@@ -16,44 +16,40 @@
 
 package com.netflix.spinnaker.fiat.providers;
 
-import com.netflix.spinnaker.fiat.model.Authorization;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 import com.netflix.spinnaker.fiat.model.resources.Application;
-import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import lombok.NonNull;
+import java.util.function.Predicate;
 
-public class DefaultApplicationProvider extends BaseProvider<Application>
+public class DefaultApplicationResourceProvider extends BaseResourceProvider<Application>
     implements ResourceProvider<Application> {
 
   private final Front50Service front50Service;
   private final ClouddriverService clouddriverService;
+  private final ResourcePermissionProvider<Application> permissionProvider;
 
   private final boolean allowAccessToUnknownApplications;
-  private final Authorization executeFallback;
 
-  public DefaultApplicationProvider(
+  public DefaultApplicationResourceProvider(
       Front50Service front50Service,
       ClouddriverService clouddriverService,
-      boolean allowAccessToUnknownApplications,
-      Authorization executeFallback) {
-    super();
-
+      ResourcePermissionProvider<Application> permissionProvider,
+      boolean allowAccessToUnknownApplications) {
     this.front50Service = front50Service;
     this.clouddriverService = clouddriverService;
+    this.permissionProvider = permissionProvider;
     this.allowAccessToUnknownApplications = allowAccessToUnknownApplications;
-    this.executeFallback = executeFallback;
   }
 
   @Override
@@ -70,34 +66,40 @@ public class DefaultApplicationProvider extends BaseProvider<Application>
   @Override
   protected Set<Application> loadAll() throws ProviderException {
     try {
-      Map<String, Application> appByName =
-          front50Service.getAllApplicationPermissions().stream()
-              .collect(Collectors.toMap(Application::getName, Function.identity()));
+      List<Application> front50Applications = front50Service.getAllApplicationPermissions();
+      List<Application> clouddriverApplications = clouddriverService.getApplications();
 
-      clouddriverService.getApplications().stream()
-          .filter(app -> !appByName.containsKey(app.getName()))
-          .forEach(app -> appByName.put(app.getName(), app));
+      // Stream front50 first so that if there's a name collision, we'll keep that one instead of
+      // the clouddriver application (since front50 might have permissions stored on it, but the
+      // clouddriver version definitely won't)
+      List<Application> applications =
+          Streams.concat(front50Applications.stream(), clouddriverApplications.stream())
+              .filter(distinctByKey(Application::getName))
+              // Collect to a list instead of set since we're about to modify the applications
+              .collect(toImmutableList());
 
-      Set<Application> applications;
+      applications.forEach(
+          application ->
+              application.setPermissions(permissionProvider.getPermissions(application)));
 
       if (allowAccessToUnknownApplications) {
         // no need to include applications w/o explicit permissions if we're allowing access to
         // unknown applications by default
-        applications =
-            appByName.values().stream()
-                .filter(a -> !a.getPermissions().isEmpty())
-                .collect(Collectors.toSet());
+        return applications.stream()
+            .filter(a -> !a.getPermissions().isEmpty())
+            .collect(toImmutableSet());
       } else {
-        applications = new HashSet<>(appByName.values());
+        return ImmutableSet.copyOf(applications);
       }
-
-      // Fallback authorization for legacy applications that are missing EXECUTE permissions
-      applications.forEach(this::ensureExecutePermission);
-
-      return applications;
-    } catch (Exception e) {
+    } catch (RuntimeException e) {
       throw new ProviderException(this.getClass(), e);
     }
+  }
+
+  // Keeps only the first object with the key
+  private static Predicate<Application> distinctByKey(Function<Application, String> keyExtractor) {
+    Set<String> seenKeys = new HashSet<>();
+    return t -> seenKeys.add(keyExtractor.apply(t));
   }
 
   private Set<Application> getAllApplications(
@@ -117,31 +119,5 @@ public class DefaultApplicationProvider extends BaseProvider<Application>
     }
 
     return isRestricted ? super.getAllRestricted(roles, isAdmin) : super.getAllUnrestricted();
-  }
-
-  /**
-   * Set EXECUTE authorization(s) for the application. For applications that already have EXECUTE
-   * set, this will be a no-op. For the remaining applications, we'll add EXECUTE based on the value
-   * of the `executeFallback` flag.
-   */
-  private void ensureExecutePermission(@NonNull Application application) {
-    Permissions permissions = application.getPermissions();
-
-    if (permissions == null || !permissions.isRestricted()) {
-      return;
-    }
-
-    Map<Authorization, List<String>> authorizations =
-        Arrays.stream(Authorization.values())
-            .collect(
-                Collectors.toMap(
-                    Function.identity(),
-                    a -> Optional.ofNullable(permissions.get(a)).orElse(new ArrayList<>())));
-
-    if (authorizations.get(Authorization.EXECUTE).isEmpty()) {
-      authorizations.put(Authorization.EXECUTE, authorizations.get(this.executeFallback));
-    }
-
-    application.setPermissions(Permissions.Builder.factory(authorizations).build());
   }
 }

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountResourceProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountResourceProvider.java
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class DefaultServiceAccountProvider extends BaseProvider<ServiceAccount>
+public class DefaultServiceAccountResourceProvider extends BaseResourceProvider<ServiceAccount>
     implements ResourceProvider<ServiceAccount> {
 
   private final Front50Service front50Service;
@@ -41,7 +41,7 @@ public class DefaultServiceAccountProvider extends BaseProvider<ServiceAccount>
   private final FiatRoleConfig fiatRoleConfig;
 
   @Autowired
-  public DefaultServiceAccountProvider(
+  public DefaultServiceAccountResourceProvider(
       Front50Service front50Service, FiatRoleConfig fiatRoleConfig) {
     super();
     this.front50Service = front50Service;

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/Front50ApplicationResourcePermissionSource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import com.netflix.spinnaker.fiat.model.Authorization;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public final class Front50ApplicationResourcePermissionSource
+    implements ResourcePermissionSource<Application> {
+
+  private final Authorization executeFallback;
+
+  public Front50ApplicationResourcePermissionSource(Authorization executeFallback) {
+    this.executeFallback = executeFallback;
+  }
+
+  @Override
+  public Permissions getPermissions(Application resource) {
+    Permissions storedPermissions = resource.getPermissions();
+    if (storedPermissions == null || !storedPermissions.isRestricted()) {
+      return Permissions.EMPTY;
+    }
+
+    Map<Authorization, List<String>> authorizations =
+        Arrays.stream(Authorization.values()).collect(toMap(identity(), storedPermissions::get));
+
+    // If the execute permission wasn't set, copy the permissions from whatever is specified in the
+    // config's executeFallback flag
+    if (authorizations.get(Authorization.EXECUTE).isEmpty()) {
+      authorizations.put(Authorization.EXECUTE, authorizations.get(executeFallback));
+    }
+
+    return Permissions.Builder.factory(authorizations).build();
+  }
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderException.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ProviderException.java
@@ -16,7 +16,9 @@
 
 package com.netflix.spinnaker.fiat.providers;
 
-public class ProviderException extends RuntimeException {
+import com.netflix.spinnaker.kork.exceptions.IntegrationException;
+
+public class ProviderException extends IntegrationException {
 
   private Class provider;
 

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionProvider.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+
+/**
+ * A ResourcePermissionProvider is responsible for supplying the full set of Permissions for a
+ * specific Resource.
+ *
+ * @param <T> the type of Resource for which this ResourcePermissionProvider supplies Permissions.
+ */
+public interface ResourcePermissionProvider<T extends Resource> {
+
+  Permissions getPermissions(T resource);
+}

--- a/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionSource.java
+++ b/fiat-roles/src/main/java/com/netflix/spinnaker/fiat/providers/ResourcePermissionSource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.providers;
+
+import com.netflix.spinnaker.fiat.model.resources.Permissions;
+import com.netflix.spinnaker.fiat.model.resources.Resource;
+
+/**
+ * A ResourcePermissionSource is capable of resolving the Permissions for a specified Resource from
+ * a specified single source.
+ *
+ * <p>Note that while the API signature matches ResourcePermissionProvider the intent of
+ * ResourcePermissionSource is to model a single source of Permissions (for example CloudDriver as a
+ * source of Account permissions), while ResourcePermissionProvider is responsible for supplying the
+ * computed Permission considering all available ResourcePermissionSources.
+ *
+ * @param <T> the type of Resource this ResourcePermissionSource will supply Permissions for
+ */
+public interface ResourcePermissionSource<T extends Resource> {
+  Permissions getPermissions(T resource);
+}

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseResourceProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/BaseResourceProviderSpec.groovy
@@ -27,7 +27,7 @@ import groovy.transform.builder.SimpleStrategy
 import spock.lang.Specification
 import spock.lang.Subject
 
-class BaseProviderSpec extends Specification {
+class BaseResourceProviderSpec extends Specification {
 
   private static Authorization R = Authorization.READ
   private static Authorization W = Authorization.WRITE
@@ -51,7 +51,7 @@ class BaseProviderSpec extends Specification {
 
   def "should get all unrestricted"() {
     setup:
-    @Subject provider = new TestResourceProvider()
+    @Subject provider = new TestResourceResourceProvider()
 
     when:
     provider.all = [noReqGroups]
@@ -72,7 +72,7 @@ class BaseProviderSpec extends Specification {
 
   def "should get restricted"() {
     setup:
-    @Subject provider = new TestResourceProvider()
+    @Subject provider = new TestResourceResourceProvider()
 
     when:
     provider.all = [noReqGroups]
@@ -111,7 +111,7 @@ class BaseProviderSpec extends Specification {
     thrown IllegalArgumentException
   }
 
-  class TestResourceProvider extends BaseProvider<TestResource> {
+  class TestResourceResourceProvider extends BaseResourceProvider<TestResource> {
     Set<TestResource> all = new HashSet<>()
 
     @Override

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultApplicationProviderSpec.groovy
@@ -34,8 +34,9 @@ class DefaultApplicationProviderSpec extends Specification {
 
   ClouddriverService clouddriverService = Mock(ClouddriverService)
   Front50Service front50Service = Mock(Front50Service)
+  ResourcePermissionProvider<Application> defaultProvider = new AggregatingResourcePermissionProvider<>([new Front50ApplicationResourcePermissionSource(Authorization.READ)])
 
-  @Subject DefaultApplicationProvider provider
+  @Subject DefaultApplicationResourceProvider provider
 
   def makePerms(Map<Authorization, List<String>> auths) {
     return Permissions.Builder.factory(auths).build()
@@ -59,7 +60,7 @@ class DefaultApplicationProviderSpec extends Specification {
       ]
     }
 
-    provider = new DefaultApplicationProvider(front50Service, clouddriverService, allowAccessToUnknownApplications, Authorization.READ)
+    provider = new DefaultApplicationResourceProvider(front50Service, clouddriverService, defaultProvider, allowAccessToUnknownApplications)
 
     when:
     def restrictedResult = provider.getAllRestricted([new Role(role)] as Set<Role>, false)
@@ -91,9 +92,8 @@ class DefaultApplicationProviderSpec extends Specification {
 
     when:
     app.setPermissions(makePerms(givenPermissions))
-    provider = new DefaultApplicationProvider(
-        front50Service, clouddriverService, allowAccessToUnknownApplications, Authorization.READ
-    )
+    provider = new DefaultApplicationResourceProvider(
+        front50Service, clouddriverService, defaultProvider, allowAccessToUnknownApplications)
     def resultApps = provider.getAll()
 
     then:
@@ -106,19 +106,20 @@ class DefaultApplicationProviderSpec extends Specification {
     where:
     givenPermissions           | allowAccessToUnknownApplications || expectedPermissions
     [:]                        | false                            || [:]
-    [(R): ['r']]               | false                            || [(R): ['r'], (W): [], (E): ['r']]
-    [(R): ['r'], (E): ['foo']] | false                            || [(R): ['r'], (W): [], (E): ['foo']]
-    [(R): ['r']]               | true                             || [(R): ['r'], (W): [], (E): ['r']]
+    [(R): ['r']]               | false                            || [(R): ['r'], (E): ['r']]
+    [(R): ['r'], (E): ['foo']] | false                            || [(R): ['r'], (E): ['foo']]
+    [(R): ['r']]               | true                             || [(R): ['r'], (E): ['r']]
   }
 
   @Unroll
   def "should add fallback execute permissions based on executeFallback value" () {
     setup:
     def app = new Application().setName("app")
+    def provider = new AggregatingResourcePermissionProvider([new Front50ApplicationResourcePermissionSource(fallback)])
 
     when:
     app.setPermissions(makePerms(givenPermissions))
-    provider = new DefaultApplicationProvider(front50Service, clouddriverService, false, fallback)
+    provider = new DefaultApplicationResourceProvider(front50Service, clouddriverService, provider, false)
     def resultApps = provider.getAll()
 
     then:
@@ -130,7 +131,7 @@ class DefaultApplicationProviderSpec extends Specification {
 
     where:
     fallback    || givenPermissions         || expectedPermissions
-    R           || [(R): ['r']]             || [(R): ['r'], (W): [], (E): ['r']]
+    R           || [(R): ['r']]             || [(R): ['r'], (E): ['r']]
     W           || [(R): ['r'], (W): ['w']] || [(R): ['r'], (W): ['w'], (E): ['w']]
   }
 }

--- a/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
+++ b/fiat-roles/src/test/groovy/com/netflix/spinnaker/fiat/providers/DefaultServiceAccountProviderSpec.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.fiat.providers.internal.Front50Service
 import org.apache.commons.collections4.CollectionUtils
 import spock.lang.Shared
 import spock.lang.Specification
-import spock.lang.Subject
 import spock.lang.Unroll
 
 class DefaultServiceAccountProviderSpec extends Specification {
@@ -48,7 +47,7 @@ class DefaultServiceAccountProviderSpec extends Specification {
     FiatRoleConfig fiatRoleConfig = Mock(FiatRoleConfig) {
       isOrMode() >> false
     }
-    DefaultServiceAccountProvider provider = new DefaultServiceAccountProvider(front50Service, fiatRoleConfig)
+    DefaultServiceAccountResourceProvider provider = new DefaultServiceAccountResourceProvider(front50Service, fiatRoleConfig)
 
     when:
     def result = provider.getAllRestricted(input.collect { new Role(it) } as Set, isAdmin)
@@ -80,7 +79,7 @@ class DefaultServiceAccountProviderSpec extends Specification {
     FiatRoleConfig fiatRoleConfig = Mock(FiatRoleConfig) {
       isOrMode() >> true
     }
-    DefaultServiceAccountProvider provider = new DefaultServiceAccountProvider(front50Service, fiatRoleConfig)
+    DefaultServiceAccountResourceProvider provider = new DefaultServiceAccountResourceProvider(front50Service, fiatRoleConfig)
 
     when:
     def result = provider.getAllRestricted(input.collect { new Role(it) } as Set, isAdmin)

--- a/fiat-web/fiat-web.gradle
+++ b/fiat-web/fiat-web.gradle
@@ -28,6 +28,7 @@ dependencies {
   implementation "com.netflix.spinnaker.kork:kork-core"
   implementation "com.netflix.spinnaker.kork:kork-web"
   implementation "com.netflix.spinnaker.kork:kork-secrets-aws"
+  implementation "com.netflix.spinnaker.kork:kork-secrets-gcp"
   implementation "com.netflix.spinnaker.kork:kork-stackdriver"
   implementation "com.netflix.spinnaker.kork:kork-swagger"
   implementation "net.logstash.logback:logstash-logback-encoder"

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/DefaultResourcePermissionConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.fiat.config;
+
+import com.netflix.spinnaker.fiat.model.resources.Account;
+import com.netflix.spinnaker.fiat.model.resources.Application;
+import com.netflix.spinnaker.fiat.model.resources.BuildService;
+import com.netflix.spinnaker.fiat.providers.*;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class DefaultResourcePermissionConfig {
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.source.account.resource.enabled",
+      matchIfMissing = true)
+  ResourcePermissionSource<Account> accountResourcePermissionSource() {
+    return new AccessControlledResourcePermissionSource<>();
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.provider.account",
+      havingValue = "default",
+      matchIfMissing = true)
+  public ResourcePermissionProvider<Account> defaultAccountPermissionProvider(
+      List<ResourcePermissionSource<Account>> sources) {
+    return new AggregatingResourcePermissionProvider<>(sources);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.source.application.front50.enabled",
+      matchIfMissing = true)
+  ResourcePermissionSource<Application> front50ResourcePermissionSource(
+      FiatServerConfigurationProperties fiatServerConfigurationProperties) {
+    return new Front50ApplicationResourcePermissionSource(
+        fiatServerConfigurationProperties.getExecuteFallback());
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.provider.application",
+      havingValue = "default",
+      matchIfMissing = true)
+  public ResourcePermissionProvider<Application> defaultApplicationPermissionProvider(
+      List<ResourcePermissionSource<Application>> sources) {
+    return new AggregatingResourcePermissionProvider<>(sources);
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.source.account.resource.enabled",
+      matchIfMissing = true)
+  ResourcePermissionSource<BuildService> buildServiceResourcePermissionSource() {
+    return new AccessControlledResourcePermissionSource<>();
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "auth.permissions.provider.build-service",
+      havingValue = "default",
+      matchIfMissing = true)
+  public ResourcePermissionProvider<BuildService> defaultBuildServicePermissionProvider(
+      List<ResourcePermissionSource<BuildService>> sources) {
+    return new AggregatingResourcePermissionProvider<>(sources);
+  }
+}

--- a/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
+++ b/fiat-web/src/main/java/com/netflix/spinnaker/fiat/config/FiatConfig.java
@@ -2,9 +2,11 @@ package com.netflix.spinnaker.fiat.config;
 
 import com.google.common.collect.ImmutableList;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spinnaker.fiat.model.resources.Application;
 import com.netflix.spinnaker.fiat.model.resources.Role;
 import com.netflix.spinnaker.fiat.permissions.ExternalUser;
-import com.netflix.spinnaker.fiat.providers.DefaultApplicationProvider;
+import com.netflix.spinnaker.fiat.providers.DefaultApplicationResourceProvider;
+import com.netflix.spinnaker.fiat.providers.ResourcePermissionProvider;
 import com.netflix.spinnaker.fiat.providers.internal.ClouddriverService;
 import com.netflix.spinnaker.fiat.providers.internal.Front50Service;
 import com.netflix.spinnaker.fiat.roles.UserRolesProvider;
@@ -68,15 +70,16 @@ public class FiatConfig extends WebMvcConfigurerAdapter {
   }
 
   @Bean
-  DefaultApplicationProvider applicationProvider(
+  DefaultApplicationResourceProvider applicationProvider(
       Front50Service front50Service,
       ClouddriverService clouddriverService,
+      ResourcePermissionProvider<Application> permissionProvider,
       FiatServerConfigurationProperties properties) {
-    return new DefaultApplicationProvider(
+    return new DefaultApplicationResourceProvider(
         front50Service,
         clouddriverService,
-        properties.isAllowAccessToUnknownApplications(),
-        properties.getExecuteFallback());
+        permissionProvider,
+        properties.isAllowAccessToUnknownApplications());
   }
 
   /**


### PR DESCRIPTION
This is a slight tweak on top of spinnaker/fiat#478:

Adds a ResourcePermissionSource - a place to get permissions from, and
ResourcePermissionProvider - the API for callers

The default ResourcePermissionProvider is an aggregator across all ResourcePermissionSources

DefaultResourcePermissionConfig allows opting out of all the default opinions if someone wants to customize/extend/override any of the default behaviour 

Let's discuss at some point today/tomorrow